### PR TITLE
Added initial sort option (refname) to set committerdate as primary s…

### DIFF
--- a/tagz.py
+++ b/tagz.py
@@ -221,7 +221,7 @@ def main():
 
         # Identify the latest two tags.
         prev_tags = (git(path,
-                         'for-each-ref refs/tags --sort=-committerdate '
+                         'for-each-ref refs/tags --sort=-refname --sort=-committerdate '
                          '--format="%(refname)" --count=2')
                      .replace('refs/tags/', '')
                      .strip(' \n')


### PR DESCRIPTION
…ort (to eliminate the repetition of the inital tag of the same object as the most recent tag).

This solves the (mild annoyance, really) wherein you're pulling the "most recent two tags" but one or both is actually not the most recent *tag* -- it's the most recently tagged *object* but sorting by committerdate alone returns tags on the same object in chronological order. This forces a sort by of committerdate, then refname.